### PR TITLE
More refactoring

### DIFF
--- a/issues.py
+++ b/issues.py
@@ -66,7 +66,7 @@ DESC_TEMPLATE="""
 {alert_url}
 
 ----
-This issue was automatically generated from a GitHub alert, and will be automaticall resolved once underlying problem is fixed.
+This issue was automatically generated from a GitHub alert, and will be automatically resolved once the underlying problem is fixed.
 DO NOT MODIFY DESCRIPTION BELOW LINE.
 GH_ALERT_LOOKUP={repo_name}/code_scanning/{alert_num}
 """

--- a/issues.py
+++ b/issues.py
@@ -85,7 +85,7 @@ def jira_webhook():
     if not hmac.compare_digest(request.args.get('secret_token', '').encode('utf-8'), KEY):
         return jsonify({"code": 403, "error": "Unauthorized"}), 403
 
-    json_dict = json.loads(request.data)
+    json_dict = json.loads(request.data.decode('utf-8'))
     event = json_dict['webhookEvent']
 
     # we only care about updates and deletions
@@ -279,8 +279,8 @@ def update_alert(repo_id, alert_num, state):
 
 
 def get_issue_id_from_desc(desc):
-    result = re.search('GH_ALERT_LOOKUP=.*$', desc, re.MULTILINE)
-    return '' if result is None else result[0][16:]
+    result = re.search('GH_ALERT_LOOKUP=(.*)$', desc, re.MULTILINE)
+    return '' if result is None else result.group(1)
 
 
 def get_issue_id(issue):
@@ -289,7 +289,7 @@ def get_issue_id(issue):
 
 def parse_issue_id(iid):
    m = re.match('^(.*)/code_scanning/([0-9]+)$', iid)
-   return m[1], m[2]
+   return m.group(1), m.group(2)
 
 def fetch_issues(repo_name, alert_num=""):
     issue_search = 'project={jira_project} and description ~ "\\"GH_ALERT_LOOKUP={repo_name}/code_scanning/{alert_num}\\""'.format(

--- a/issues.py
+++ b/issues.py
@@ -81,7 +81,6 @@ def jira_webhook():
     # Apparently, JIRA does not support an authentication mechanism for webhooks.
     # To make it slightly more secure, we will just pass a secret token as a URL parameter
     # In addition to that, it might be sensible to only whitelist the JIRA IP address
-    #if not hmac.compare_digest(request.args.get('secret_token', ''), KEY):
     if not hmac.compare_digest(request.args.get('secret_token', '').encode('utf-8'), KEY):
         return jsonify({"code": 403, "error": "Unauthorized"}), 403
 
@@ -187,8 +186,6 @@ def update_jira(repo_name, transition,
 
     issue = existing_issues[0]
     app.logger.info('Found issue to update: ' + issue.key)
-
-    jira_transitions = {t['name'] : t['id'] for t in jira.transitions(issue)}
 
     if transition in ["closed_by_user", "fixed"]:
         transition_issue(issue, CLOSE_TRANSITION)

--- a/issues.py
+++ b/issues.py
@@ -179,11 +179,10 @@ def update_jira(repo_name, transition,
     existing_issues = fetch_issues(repo_name, alert_num)
 
     if not existing_issues:
-        app.logger.error('No issues found for query: ' + issue_search)
         return jsonify({"code": 400, "error": "Issue not found"}), 400
 
     if len(existing_issues) > 1:
-        app.logger.warning('Multiple issues found for: ' + issue_search + '. Selecting by min id.')
+        app.logger.warning('Multiple issues found. Selecting by min id.')
         existing_issues.sort(key=lambda i: i.id)
 
     issue = existing_issues[0]
@@ -297,8 +296,12 @@ def fetch_issues(repo_name, alert_num=""):
         repo_name=repo_name,
         alert_num=alert_num,
     )
-    app.logger.info('Searching for issue to update: ' + issue_search)
-    return jira.search_issues(issue_search, maxResults=0)
+    result = jira.search_issues(issue_search, maxResults=0)
+    app.logger.info('Search {search} returned {num_results} results.'.format(
+        search=issue_search,
+        num_results=len(result)
+    ))
+    return result
 
 def transition_issue(issue, transition):
     jira_transitions = {t['name'] : t['id'] for t in jira.transitions(issue)}

--- a/issues.py
+++ b/issues.py
@@ -104,10 +104,10 @@ def jira_webhook():
     repo_id, alert_num = parse_issue_id(iid)
 
     if event == JIRA_UPDATE_EVENT:
-      if istatus == REOPEN_TRANSITION:
-          open_alert(repo_id, alert_num)
-      elif istatus == CLOSE_TRANSITION:
-          close_alert(repo_id, alert_num)
+        if istatus == REOPEN_TRANSITION:
+            open_alert(repo_id, alert_num)
+        elif istatus == CLOSE_TRANSITION:
+            close_alert(repo_id, alert_num)
     else:
         close_alert(repo_id, alert_num)
 
@@ -287,8 +287,8 @@ def get_issue_id(issue):
 
 
 def parse_issue_id(iid):
-   m = re.match('^(.*)/code_scanning/([0-9]+)$', iid)
-   return m.group(1), m.group(2)
+    m = re.match('^(.*)/code_scanning/([0-9]+)$', iid)
+    return m.group(1), m.group(2)
 
 def fetch_issues(repo_name, alert_num=""):
     issue_search = 'project={jira_project} and description ~ "\\"GH_ALERT_LOOKUP={repo_name}/code_scanning/{alert_num}\\""'.format(
@@ -307,12 +307,12 @@ def transition_issue(issue, transition):
     jira_transitions = {t['name'] : t['id'] for t in jira.transitions(issue)}
     if transition not in jira_transitions:
         app.logger.error('Transition "{transition}" not available for {issue_key}. Valid transition: {jira_transitions}'.format(
-                    transition=transition,
-                    issue_key=issue.key,
-                    jira_transitions=list(jira_transitions)
-                ))
+            transition=transition,
+            issue_key=issue.key,
+            jira_transitions=list(jira_transitions)
+        ))
         raise Exception("Invalid JIRA transition")
-    
+
     jira.transition_issue(issue, jira_transitions[transition])
 
 
@@ -352,22 +352,22 @@ def sync_repo(repo_name):
     # create missing issues
     for key in cs_alerts:
         if key not in jira_issues:
-          alert = cs_alerts[key]
-          rule = alert['rule']
+            alert = cs_alerts[key]
+            rule = alert['rule']
 
-          app.logger.info(
-              'Creating missing issue for alert {num} in {repo_name}.'.format(
-                  num=alert['number'],
-                  repo_name=repo_name
-              )
-          )
-          jira_issues[key] = create_issue(
-              repo_name,
-              rule['id'],
-              rule['description'],
-              alert['html_url'],
-              alert['number']
-          )
+            app.logger.info(
+                'Creating missing issue for alert {num} in {repo_name}.'.format(
+                    num=alert['number'],
+                    repo_name=repo_name
+                )
+            )
+            jira_issues[key] = create_issue(
+                repo_name,
+                rule['id'],
+                rule['description'],
+                alert['html_url'],
+                alert['number']
+            )
 
     # adjust issue states
     for key in cs_alerts:

--- a/issues.py
+++ b/issues.py
@@ -10,6 +10,7 @@ from jira import JIRA
 import itertools
 import re
 from datetime import datetime
+from types import SimpleNamespace
 
 
 GH_API_URL = os.getenv("GH_API_URL")
@@ -60,7 +61,7 @@ def auth_is_valid(signature, request_body):
         signature.encode('utf-8'), ('sha256=' + hmac.new(KEY, request_body, hashlib.sha256).hexdigest()).encode('utf-8')
     )
 
-DESC_TEMPLATE="""
+JIRA_DESC_TEMPLATE="""
 {rule_desc}
 
 {alert_url}
@@ -68,7 +69,10 @@ DESC_TEMPLATE="""
 ----
 This issue was automatically generated from a GitHub alert, and will be automatically resolved once the underlying problem is fixed.
 DO NOT MODIFY DESCRIPTION BELOW LINE.
-GH_ALERT_LOOKUP={repo_name}/code_scanning/{alert_num}
+REPOSITORY_NAME={repo_name}
+ALERT_NUMBER={alert_num}
+REPOSITORY_KEY={repo_key}
+ALERT_KEY={alert_key}
 """
 
 last_repo_syncs = {}
@@ -84,25 +88,23 @@ def jira_webhook():
     if not hmac.compare_digest(request.args.get('secret_token', '').encode('utf-8'), KEY):
         return jsonify({"code": 403, "error": "Unauthorized"}), 403
 
-    json_dict = json.loads(request.data.decode('utf-8'))
-    event = json_dict['webhookEvent']
+    payload = json.loads(request.data.decode('utf-8'), object_hook=lambda p: SimpleNamespace(**p))
+    event = payload.webhookEvent
+    issue = payload.issue
+
+    if not is_managed(issue):
+        app.logger.info('Ignoring issue not related to a code scanning alert.')
+        return jsonify({}), 200
 
     # we only care about updates and deletions
     if event not in [JIRA_UPDATE_EVENT, JIRA_DELETE_EVENT]:
         app.logger.info('Ignoring event "{event}".'.format(event=event))
         return jsonify({}), 200
 
-    idesc = json_dict['issue']['fields']['description']
-    istatus = json_dict['issue']['fields']['status']['name']
-    iid = get_issue_id_from_desc(idesc)
-
-    if iid == '':
-        app.logger.info('Ignoring issue not related to a code scanning alert.')
-        return jsonify({}), 200
-
-    repo_id, alert_num = parse_issue_id(iid)
+    repo_id, alert_num, _, _ = get_alert_info(issue)
 
     if event == JIRA_UPDATE_EVENT:
+        istatus = issue.fields.status.name
         if istatus == REOPEN_TRANSITION:
             open_alert(repo_id, alert_num)
         elif istatus == CLOSE_TRANSITION:
@@ -274,31 +276,55 @@ def update_alert(repo_id, alert_num, state):
     resp.raise_for_status()
 
 
-def get_issue_id_from_desc(desc):
-    result = re.search('GH_ALERT_LOOKUP=(.*)$', desc, re.MULTILINE)
-    return '' if result is None else result.group(1)
+def is_managed(issue):
+    if parse_alert_info(issue.fields.description)[0] is None:
+        return False
+    return True
 
 
-def get_issue_id(issue):
-    return get_issue_id_from_desc(issue.fields.description)
+def parse_alert_info(desc):
+    '''
+    Parse all the fieldsin an issue's description and return
+    them as a tuple. If parsing fails for one of the fields,
+    return a tuple of None's.
+    '''
+    failed = None, None, None, None
+    m = re.search('REPOSITORY_NAME=(.*)$', desc, re.MULTILINE)
+    if m is None:
+        return failed
+    repo_id = m.group(1)
+    m = re.search('ALERT_NUMBER=(.*)$', desc, re.MULTILINE)
+    if m is None:
+        return failed
+    alert_num = m.group(1)
+    m = re.search('REPOSITORY_KEY=(.*)$', desc, re.MULTILINE)
+    if m is None:
+        return failed
+    repo_key = m.group(1)
+    m = re.search('ALERT_KEY=(.*)$', desc, re.MULTILINE)
+    if m is None:
+        return failed
+    alert_key = m.group(1)
+    return repo_id, alert_num, repo_key, alert_key
 
 
-def parse_issue_id(iid):
-    m = re.match('^(.*)/code_scanning/([0-9]+)$', iid)
-    return m.group(1), m.group(2)
+def get_alert_info(issue):
+    return parse_alert_info(issue.fields.description)
 
-def fetch_issues(repo_name, alert_num=""):
-    issue_search = 'project={jira_project} and description ~ "\\"GH_ALERT_LOOKUP={repo_name}/code_scanning/{alert_num}\\""'.format(
+
+def fetch_issues(repo_name, alert_num=None):
+    key = make_key(repo_name + (('/' + str(alert_num)) if alert_num is not None else ''))
+    issue_search = 'project={jira_project} and description ~ "{key}"'.format(
         jira_project=JIRA_PROJECT,
-        repo_name=repo_name,
-        alert_num=alert_num,
+        key=key
     )
-    result = jira.search_issues(issue_search, maxResults=0)
+    result = list(filter(is_managed, jira.search_issues(issue_search, maxResults=0)))
     app.logger.info('Search {search} returned {num_results} results.'.format(
         search=issue_search,
         num_results=len(result)
     ))
     return result
+
 
 def transition_issue(issue, transition):
     jira_transitions = {t['name'] : t['id'] for t in jira.transitions(issue)}
@@ -317,11 +343,13 @@ def create_issue(repo_name, rule_id, rule_desc, alert_url, alert_num):
     return jira.create_issue(
         project=JIRA_PROJECT,
         summary='{rule} in {repo}'.format(rule=rule_id, repo=repo_name),
-        description=DESC_TEMPLATE.format(
+        description=JIRA_DESC_TEMPLATE.format(
             rule_desc=rule_desc,
             alert_url=alert_url,
             repo_name=repo_name,
             alert_num=alert_num,
+            repo_key=make_key(repo_name),
+            alert_key=make_key(repo_name + '/' + str(alert_num))
         ),
         issuetype={'name': 'Bug'}
     )
@@ -331,12 +359,12 @@ def sync_repo(repo_name):
     app.logger.info('Starting full sync for repository "{repo_name}"...'.format(repo_name=repo_name))
 
     # fetch code scanning alerts from GitHub
-    cs_alerts = {repo_name + '/code_scanning/' + str(a['number']): a for a in get_alerts(repo_name)}
+    cs_alerts = {make_key(repo_name + '/' + str(a['number'])): a for a in get_alerts(repo_name)}
 
     # fetch issues from JIRA and delete duplicates and ones which can't be matched
     jira_issues = {}
     for i in fetch_issues(repo_name):
-        key = get_issue_id(i)
+        _, _, _, key = get_alert_info(i)
         if key in jira_issues:
             app.logger.info('Deleting duplicate jira alert issue.')
             i.delete()   # TODO - seems scary, are we sure....
@@ -391,3 +419,9 @@ def sync_repo(repo_name):
                 )
             )
             transition_issue(issue, CLOSE_TRANSITION)
+
+
+def make_key(s):
+    sha_1 = hashlib.sha1()
+    sha_1.update(s.encode('utf-8'))
+    return sha_1.hexdigest()

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,4 +1,0 @@
-extraction:
-  python:
-    python_setup:
-      version: 3


### PR DESCRIPTION
@johnlugton This fixes some of the issues I encountered, including the problem with the JIRA search. I realize that there are a lot of changes in there, but I tried to address a specific topic within each commit.

The other things which I plan to do are:
* Improve performance. Currently, there is a bit of a feedback effect when a change occurs: Github sends webhook for alert change -> we adjust the JIRA ticket -> JIRA sends a webhook for that change -> We use the GitHub API to first check whether we actually need to propagate that change. This has some overhead, particularly during a full sync. It might make sense to use some sort of cache to avoid that.
* Documentation. I think I want to write a few paragraphs on how to set this up properly.
* Race conditions. I think there are some race conditions, since this web framework seems to serve the hooks concurrently, counter to my expectations.