### PR TITLE
CLI Tool

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5,7 +5,14 @@ import os
 import sys
 import json
 import util
+import logging
 
+root = logging.getLogger()
+root.setLevel(logging.DEBUG)
+
+handler = logging.StreamHandler(sys.stdout)
+handler.setLevel(logging.DEBUG)
+root.addHandler(handler)
 
 def fail(msg):
     print(msg)
@@ -40,7 +47,7 @@ def sync(args):
 
     github = ghlib.GitHub(args.gh_url, args.gh_user, args.gh_token)
     jira = jiralib.Jira(args.jira_url, args.jira_user, args.jira_token)
-    util.sync_repo(github.getRepository(args.gh_org + '/' + args.gh_repo), jira.getProject(args.jira_project))
+    util.Sync(github, jira.getProject(args.jira_project)).sync_repo(args.gh_org + '/' + args.gh_repo)
 
 
 def check_hooks(args):

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,230 @@
+import argparse
+import ghlib
+import jiralib
+import os
+import sys
+import json
+import util
+
+
+def fail(msg):
+    print(msg)
+    sys.exit(1)
+
+
+def serve(args):
+    pass
+
+
+def sync(args):
+    if not args.gh_url or not args.jira_url:
+        fail('Both GitHub and JIRA URL have to be specified!')
+
+    if not args.gh_user or not args.gh_token:
+        fail('No GitHub credentials specified!')
+
+    if not args.jira_user or not args.jira_token:
+        fail('No JIRA credentials specified!')
+
+    if not args.gh_org:
+        fail('No GitHub organization specified!')
+
+    if not args.gh_repo:
+        fail('No GitHub repository specified!')
+
+    github = ghlib.GitHub(args.gh_url, args.gh_user, args.gh_token)
+    jira = jiralib.Jira(args.jira_url, args.jira_user, args.jira_token)
+    util.sync_repo(github.getRepository(args.gh_org + '/' + args.gh_repo), jira.getProject(args.jira_project))
+
+
+def check_hooks(args):
+    pass
+
+
+def install_hooks(args):
+    if not args.hook_url:
+        fail('No hook URL specified!')
+
+    if not args.hook_secret:
+        fail('No hook secret specified!')
+
+    if not args.gh_url and not args.jira_url:
+        fail('Neither GitHub nor JIRA URL specified!')
+
+    # user wants to install a github hook
+    if args.gh_url:
+        if not args.gh_user or not args.gh_token:
+            fail('No GitHub credentials specified!')
+
+        if not args.gh_org:
+            fail('No GitHub organization specified!')
+
+        github = ghlib.GitHub(args.gh_url, args.gh_user, args.gh_token)
+
+        if args.gh_repo:
+            ghrepo = github.getRepository(args.gh_org + '/' + args.gh_repo)
+            ghrepo.create_hook(url=args.hook_url, secret=args.hook_secret)
+        else:
+            github.create_org_hook(url=args.hook_url, secret=args.hook_secret)
+
+    # user wants to install a JIRA hook
+    if args.jira_url:
+        if not args.jira_user or not args.jira_token:
+            fail('No JIRA credentials specified!')
+        jira = jiralib.Jira(args.jira_url, args.jira_user, args.jira_token)
+        jira.create_hook('github_jira_synchronization_hook', args.hook_url, args.hook_secret)
+
+
+def list_hooks(args):
+    if not args.gh_url and not args.jira_url:
+        fail('Neither GitHub nor JIRA URL specified!')
+
+    # user wants to list github hooks
+    if args.gh_url:
+        if not args.gh_user or not args.gh_token:
+            fail('No GitHub credentials specified!')
+
+        if not args.gh_org:
+            fail('No GitHub organization specified!')
+
+        github = ghlib.GitHub(args.gh_url, args.gh_user, args.gh_token)
+
+        if args.gh_repo:
+            for h in github.getRepository(args.gh_org + '/' + args.gh_repo).list_hooks():
+                print(json.dumps(h, indent=4))
+        else:
+            for h in github.list_org_hooks(args.gh_org):
+                print(json.dumps(h, indent=4))
+
+    # user wants to list JIRA hooks
+    if args.jira_url:
+        if not args.jira_user or not args.jira_token:
+            fail('No JIRA credentials specified!')
+
+        jira = jiralib.Jira(args.jira_url, args.jira_user, args.jira_token)
+
+        for h in jira.list_hooks():
+            print(json.dumps(h, indent=4))
+
+
+def main():
+    credential_base = argparse.ArgumentParser(add_help=False)
+    credential_base.add_argument(
+        '--gh-org',
+        help='GitHub organization'
+    )
+    credential_base.add_argument(
+        '--gh-repo',
+        help='GitHub repository'
+    )
+    credential_base.add_argument(
+        '--gh-url',
+        help='API URL of GitHub instance',
+    )
+    credential_base.add_argument(
+        '--gh-user',
+        help='GitHub user name'
+    )
+    credential_base.add_argument(
+        '--gh-token',
+        help='GitHub API token'
+    )
+    credential_base.add_argument(
+        '--jira-url',
+        help='URL of JIRA instance'
+    )
+    credential_base.add_argument(
+        '--jira-user',
+        help='GitHub user name'
+    )
+    credential_base.add_argument(
+        '--jira-token',
+        help='JIRA password'
+    )
+    credential_base.add_argument(
+        '--jira-project',
+        help='JIRA project key'
+    )
+
+    parser = argparse.ArgumentParser(prog='cs2jira')
+    subparsers = parser.add_subparsers()
+
+    # serve
+    serve = subparsers.add_parser(
+        'serve',
+        parents=[credential_base],
+        help='Spawn a webserver which keeps GitHub alerts and JIRA tickets in sync',
+        description='Spawn a webserver which keeps GitHub alerts and JIRA tickets in sync'
+    )
+    serve.set_defaults(func=serve)
+
+    # sync
+    sync_parser = subparsers.add_parser(
+        'sync',
+        parents=[credential_base],
+        help='Synchronize GitHub alerts and JIRA tickets for a given repository',
+        description='Synchronize GitHub alerts and JIRA tickets for a given repository'
+    )
+    sync_parser.set_defaults(func=sync)
+
+    # hooks
+    hooks = subparsers.add_parser(
+        'hooks',
+        help='Manage JIRA and GitHub webhooks',
+        description='Manage JIRA and GitHub webhooks'
+    )
+
+
+    hooks_subparsers = hooks.add_subparsers()
+
+    # list hooks
+    hooks_list = hooks_subparsers.add_parser(
+        'list',
+        parents=[credential_base],
+        help='List existing GitHub or JIRA webhooks',
+        description='List existing GitHub or JIRA webhooks'
+    )
+    hooks_list.set_defaults(func=list_hooks)
+
+    # install hooks
+    hooks_install = hooks_subparsers.add_parser(
+        'install',
+        parents=[credential_base],
+        help='Install existing GitHub or JIRA webhooks',
+        description='Install GitHub or JIRA webhooks'
+    )
+    hooks_install.add_argument(
+        '--hook-secret',
+        help='Webhook secret'
+    )
+    hooks_install.add_argument(
+        '--hook-url',
+        help='Webhook target url'
+    )
+    hooks_install.add_argument(
+        '--insecure-ssl',
+        action='store_true',
+        help='Install GitHub hook without SSL check'
+    )
+    hooks_install.set_defaults(func=install_hooks)
+
+    # check hooks
+    hooks_check = hooks_subparsers.add_parser(
+        'check',
+        parents=[credential_base],
+        help='Check that hooks are installed properly',
+        description='Check that hooks are installed properly'
+    )
+    hooks_check.set_defaults(func=check_hooks)
+
+
+    def print_usage(args):
+        print(parser.format_usage())
+
+    parser.set_defaults(func=print_usage)
+    args = parser.parse_args()
+
+    # run the given action
+    args.func(args)
+
+main()

--- a/cli.py
+++ b/cli.py
@@ -13,7 +13,13 @@ def fail(msg):
 
 
 def serve(args):
-    pass
+    github = ghlib.GitHub(args.gh_url, args.gh_user, args.gh_token)
+    jira = jiralib.Jira(args.jira_url, args.jira_user, args.jira_token)
+    jp = jira.getProject(args.jira_project)
+    i = jp.create_issue('repo/id', 'rule_id', 'rule_desc', 'alert_url', '15')
+    results = jp.fetch_issues('repo/id', '15')
+    print(len(results))
+
 
 
 def sync(args):
@@ -150,13 +156,13 @@ def main():
     subparsers = parser.add_subparsers()
 
     # serve
-    serve = subparsers.add_parser(
+    serve_parser = subparsers.add_parser(
         'serve',
         parents=[credential_base],
         help='Spawn a webserver which keeps GitHub alerts and JIRA tickets in sync',
         description='Spawn a webserver which keeps GitHub alerts and JIRA tickets in sync'
     )
-    serve.set_defaults(func=serve)
+    serve_parser.set_defaults(func=serve)
 
     # sync
     sync_parser = subparsers.add_parser(

--- a/gh2jira
+++ b/gh2jira
@@ -1,3 +1,3 @@
 #!/bin/sh
 HERE="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
-python "${HERE}/cli.py" $@
+python3 "${HERE}/cli.py" $@

--- a/gh2jira
+++ b/gh2jira
@@ -1,0 +1,3 @@
+#!/bin/sh
+HERE="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+python "${HERE}/cli.py" $@

--- a/ghlib.py
+++ b/ghlib.py
@@ -1,0 +1,226 @@
+import requests
+import itertools
+import logging
+import json
+import util
+
+
+WEBHOOK_CONFIG = '''
+{
+    "url": "{url}",
+    "content_type": "{content_type}",
+    "secret": "{secret}",
+    "insecure_ssl": "{insecure_ssl}",
+    "events": "{envents}",
+    "active": "{active}"
+}
+'''
+
+logger = logging.getLogger(__name__)
+
+
+class GitHub:
+    def __init__(self, url, user, token):
+        self.url = url
+        self.user = user
+        self.token = token
+
+
+    def auth(self):
+        return self.user, self.token
+
+
+    def getRepository(self, repo_id):
+        return GHRepository(self, repo_id)
+
+
+    def list_org_hooks(self, org):
+        '''requires a token with "admin:org_hook" permission!'''
+        return self.list_hooks_helper(org)
+
+
+    def list_hooks_helper(self, entity):
+        if '/' in entity:
+            etype = 'repos'
+        else:
+            etype = 'orgs'
+        for page in itertools.count(start=1):
+            resp = requests.get(
+                '{api_url}/{etype}/{ename}/hooks?per_page=100&page={page}'.format(
+                    api_url=self.url,
+                    etype=etype,
+                    ename=entity,
+                    page=page
+                ),
+                headers=util.json_accept_header(),
+                auth=self.auth(),
+                timeout=util.REQUEST_TIMEOUT
+            )
+            resp.raise_for_status()
+
+            if not resp.json():
+                break
+
+            for h in resp.json():
+                yield h
+
+    def create_org_hook(
+        self, org, url,
+        secret, active=True,
+        events=['code_scanning_alert', 'repository'],
+        insecure_ssl='0',
+        content_type='json'
+    ):
+        return self.create_hook_helper(
+            org, url,
+            secret, active,
+            events, insecure_ssl,
+            content_type
+        )
+
+
+    def create_hook_helper(
+        self, entity, url, secret, active=True,
+        events=['code_scanning_alert', 'repository'],
+        insecure_ssl='0',
+        content_type='json'
+    ):
+
+        if '/' in entity:
+            etype = 'repos'
+        else:
+            etype = 'orgs'
+
+        data = json.dumps({
+            'config': {
+                'url': url,
+                'insecure_ssl': insecure_ssl,
+                'secret': secret,
+                'content_type': content_type,
+            },
+            'events': events,
+            'active': active,
+            'name': 'web'
+        })
+        resp = requests.post(
+            '{api_url}/{etype}/{ename}/hooks'.format(
+                etype=etype,
+                ename=entity,
+                api_url=self.url
+            ),
+            headers=util.json_accept_header(),
+            data=data,
+            auth=self.auth(),
+            timeout=util.REQUEST_TIMEOUT
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+class GHRepository:
+    def __init__(self, github, repo_id):
+        self.gh = github
+        self.repo_id = repo_id
+
+
+    def list_hooks(self):
+        return self.gh.list_hooks_helper(self.repo_id)
+
+
+    def create_hook(
+        self, url,
+        secret, active=True,
+        events=['code_scanning_alert', 'repository'],
+        insecure_ssl='0',
+        content_type='json'
+    ):
+        return self.gh.create_hook_helper(
+            self.repo_id, url,
+            secret, active,
+            events, insecure_ssl,
+            content_type
+        )
+
+
+    def get_alerts(self, state = None):
+        if state:
+            state = '&state=' + state
+        else:
+            state = ''
+
+        for page in itertools.count(start=1):
+            resp = requests.get(
+                '{api_url}/repos/{repo_id}/code-scanning/alerts?per_page=100&page={page}{state}'.format(
+                    api_url=self.gh.url,
+                    repo_id=self.repo_id,
+                    page=page,
+                    state=state
+                ),
+                headers=util.json_accept_header(),
+                auth=self.gh.auth(),
+                timeout=util.REQUEST_TIMEOUT
+            )
+            resp.raise_for_status()
+
+            if not resp.json():
+                break
+
+            for a in resp.json():
+                yield a
+
+
+    def get_alert(self, alert_num):
+        resp = requests.get(
+            '{api_url}/repos/{repo_id}/code-scanning/alerts/{alert_num}'.format(
+                api_url=self.gh.url,
+                repo_id=self.repo_id,
+                alert_num=alert_num
+            ),
+            headers=util.json_accept_header(),
+            auth=self.gh.auth(),
+            timeout=util.REQUEST_TIMEOUT
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
+    def open_alert(self, alert_num):
+        state = self.get_alert(alert_num)['state']
+        if state != 'open':
+            logger.info(
+                'Reopen alert {alert_num} of repository "{repo_id}".'.format(
+                    alert_num=alert_num,
+                    repo_id=self.repo_id
+                )
+            )
+            self.update_alert(alert_num, 'open')
+
+
+    def close_alert(self, alert_num):
+        state = self.get_alert(alert_num)['state']
+        if state != 'dismissed':
+            logger.info(
+                'Closing alert {alert_num} of repository "{repo_id}".'.format(
+                    alert_num=alert_num,
+                    repo_id=self.repo_id
+                )
+            )
+            self.update_alert(alert_num, 'dismissed')
+
+
+    def update_alert(self, alert_num, state):
+        reason = ''
+        if state == 'dismissed':
+            reason = ', "dismissed_reason": "won\'t fix"'
+        data = '{{"state": "{state}"{reason}}}'.format(state=state, reason=reason)
+        resp = requests.patch(
+            '{api_url}/repos/{repo_id}/code-scanning/alerts/{alert_num}'.format(
+                api_url=self.gh.url,
+                repo_id=self.repo_id,
+                alert_num=alert_num
+            ),
+            data=data,
+            headers=util.json_accept_header(),
+            auth=self.gh.auth(),
+            timeout=util.REQUEST_TIMEOUT
+        )
+        resp.raise_for_status()

--- a/issues.py
+++ b/issues.py
@@ -79,8 +79,8 @@ def jira_webhook():
         app.logger.debug('Ignoring JIRA webhook for issue not related to a code scanning alert.')
         return jsonify({}), 200
 
-    # we only care about updates and deletions
-    if event not in [jiralib.UPDATE_EVENT, jiralib.DELETE_EVENT]:
+    # we only care about updates to issues
+    if event not in [jiralib.UPDATE_EVENT]:
         app.logger.debug('Ignoring JIRA webhook for event "{event}".'.format(event=event))
         return jsonify({}), 200
 
@@ -88,12 +88,9 @@ def jira_webhook():
     ghrepo = ghlib.GHRepository(github, repo_id)
 
     try:
-        if event == jiralib.UPDATE_EVENT:
-            if issue.is_open():
-                ghrepo.open_alert(alert_num)
-            elif issue.is_closed():
-                ghrepo.close_alert(alert_num)
-        else:
+        if issue.is_open():
+            ghrepo.open_alert(alert_num)
+        elif issue.is_closed():
             ghrepo.close_alert(alert_num)
     except HTTPError as httpe:
         # A 404 suggests that the alert doesn't exist on the

--- a/jiralib.py
+++ b/jiralib.py
@@ -1,0 +1,185 @@
+from jira import JIRA
+import hashlib
+import re
+import util
+import logging
+
+# May need to be changed depending on JIRA project type
+CLOSE_TRANSITION = "Done"
+REOPEN_TRANSITION = "To Do"
+OPEN_STATUS = "To Do"
+CLOSED_STATUS = "Done"
+
+# JIRA Webhook events
+DELETE_EVENT = 'jira:issue_deleted'
+UPDATE_EVENT = 'jira:issue_updated'
+
+DESC_TEMPLATE="""
+{rule_desc}
+
+{alert_url}
+
+----
+This issue was automatically generated from a GitHub alert, and will be automatically resolved once the underlying problem is fixed.
+DO NOT MODIFY DESCRIPTION BELOW LINE.
+REPOSITORY_NAME={repo_name}
+ALERT_NUMBER={alert_num}
+REPOSITORY_KEY={repo_key}
+ALERT_KEY={alert_key}
+"""
+
+logger = logging.getLogger(__name__)
+
+
+class Jira:
+    def __init__(self, url, user, token):
+        self.url = url
+        self.user = user
+        self.token = token
+        self.j = JIRA(url, auth=(user, token))
+
+    def getProject(self, projectkey):
+        return JiraProject(self, projectkey)
+
+
+class JiraProject:
+    def __init__(self, jira, projectkey):
+        self.jira = jira
+        self.projectkey = projectkey
+        self.j = self.jira.j
+
+
+    def create_issue(self, repo_id, rule_id, rule_desc, alert_url, alert_num):
+        raw = self.j.create_issue(
+            project=self.projectkey,
+            summary='{rule} in {repo}'.format(rule=rule_id, repo=repo_id),
+            description=DESC_TEMPLATE.format(
+                rule_desc=rule_desc,
+                alert_url=alert_url,
+                repo_name=repo_id,
+                alert_num=alert_num,
+                repo_key=util.make_key(repo_id),
+                alert_key=util.make_key(repo_id + '/' + str(alert_num))
+            ),
+            issuetype={'name': 'Bug'}
+        )
+        logger.info('Created issue {issue_key} for alert {alert_num} in {repo_id}.'.format(
+            issue_key=raw.key,
+            alert_num=alert_num,
+            repo_id=repo_id
+        ))
+
+        return JiraIssue(raw)
+
+
+    def fetch_issues(self, repo_name, alert_num=None):
+        key = util.make_key(repo_name + (('/' + str(alert_num)) if alert_num is not None else ''))
+        issue_search = 'project={jira_project} and description ~ "{key}"'.format(
+            jira_project=self.projectkey,
+            key=key
+        )
+        issues = list(filter(lambda i: i.is_managed(), [JiraIssue(self, raw) for raw in self.j.search_issues(issue_search, maxResults=0)]))
+        logger.debug('Search {search} returned {num_results} results.'.format(
+            search=issue_search,
+            num_results=len(issues)
+        ))
+        return issues
+
+
+class JiraIssue:
+    def __init__(self, project, rawissue):
+        self.project = project
+        self.rawissue = rawissue
+        self.j = self.project.j
+
+
+    def is_managed(self):
+        if parse_alert_info(self.rawissue.fields.description)[0] is None:
+            return False
+        return True
+
+
+    def get_alert_info(self):
+        return parse_alert_info(self.rawissue.fields.description)
+
+
+    def key():
+        return self.rawissue.key
+
+
+    def id():
+        return self.rawissue.id
+
+
+    def delete(self):
+        self.rawissue.delete()
+
+
+    def is_open(self):
+        return self.rawissue.fields.status.name == OPEN_STATUS
+
+
+    def is_closed(self):
+        return self.rawissue.fields.status.name == CLOSED_STATUS
+
+
+    def open(self):
+        self.transition(REOPEN_TRANSITION)
+
+
+    def close(self):
+        self.transition(CLOSE_TRANSITION)
+
+
+    def transition(self, transition):
+        jira_transitions = {t['name'] : t['id'] for t in self.j.transitions(self.rawissue)}
+        if transition not in jira_transitions:
+            logger.error('Transition "{transition}" not available for {issue_key}. Valid transitions: {jira_transitions}'.format(
+                transition=transition,
+                issue_key=self.rawissue.key,
+                jira_transitions=list(jira_transitions)
+            ))
+            raise Exception("Invalid JIRA transition")
+
+        old_issue_status = str(self.rawissue.fields.status)
+
+        if old_issue_status == OPEN_STATUS and transition == REOPEN_TRANSITION or \
+          old_issue_status == CLOSED_STATUS and transition == CLOSE_TRANSITION:
+            # nothing to do
+            return
+
+        self.j.transition_issue(self.rawissue, jira_transitions[transition])
+
+        logger.info(
+            'Adjusted status for issue {issue_key} from "{old_issue_status}" to "{new_issue_status}".'.format(
+                issue_key=self.rawissue.key,
+                old_issue_status=old_issue_status,
+                new_issue_status=CLOSED_STATUS if (old_issue_status == OPEN_STATUS) else OPEN_STATUS
+            )
+        )
+
+
+def parse_alert_info(desc):
+    '''
+    Parse all the fieldsin an issue's description and return
+    them as a tuple. If parsing fails for one of the fields,
+    return a tuple of None's.
+    '''
+    failed = None, None, None, None
+    m = re.search('REPOSITORY_NAME=(.*)$', desc, re.MULTILINE)
+    if m is None:
+        return failed
+    repo_id = m.group(1)
+    m = re.search('ALERT_NUMBER=(.*)$', desc, re.MULTILINE)
+    if m is None:
+        return failed
+    alert_num = m.group(1)
+    m = re.search('REPOSITORY_KEY=(.*)$', desc, re.MULTILINE)
+    if m is None:
+        return failed
+    repo_key = m.group(1)
+    m = re.search('ALERT_KEY=(.*)$', desc, re.MULTILINE)
+    if m is None:
+        return failed
+    alert_key = m.group(1)
+    return repo_id, alert_num, repo_key, alert_key

--- a/jiralib.py
+++ b/jiralib.py
@@ -69,7 +69,7 @@ class JiraProject:
             repo_id=repo_id
         ))
 
-        return JiraIssue(raw)
+        return JiraIssue(self, raw)
 
 
     def fetch_issues(self, repo_name, alert_num=None):
@@ -103,15 +103,16 @@ class JiraIssue:
         return parse_alert_info(self.rawissue.fields.description)
 
 
-    def key():
+    def key(self):
         return self.rawissue.key
 
 
-    def id():
+    def id(self):
         return self.rawissue.id
 
 
     def delete(self):
+        logger.info('Deleting issue {ikey}.'.format(ikey=self.key()))
         self.rawissue.delete()
 
 

--- a/jiralib.py
+++ b/jiralib.py
@@ -184,6 +184,13 @@ class JiraIssue:
 
 
     def transition(self, transition):
+        old_issue_status = str(self.rawissue.fields.status.name)
+
+        if self.get_state() and transition == REOPEN_TRANSITION or \
+        not self.get_state() and transition == CLOSE_TRANSITION:
+            # nothing to do
+            return
+
         jira_transitions = {t['name'] : t['id'] for t in self.j.transitions(self.rawissue)}
         if transition not in jira_transitions:
             logger.error('Transition "{transition}" not available for {issue_key}. Valid transitions: {jira_transitions}'.format(
@@ -192,13 +199,6 @@ class JiraIssue:
                 jira_transitions=list(jira_transitions)
             ))
             raise Exception("Invalid JIRA transition")
-
-        old_issue_status = str(self.rawissue.fields.status.name)
-
-        if self.get_state() and transition == REOPEN_TRANSITION or \
-        not self.get_state() and transition == CLOSE_TRANSITION:
-            # nothing to do
-            return
 
         self.j.transition_issue(self.rawissue, jira_transitions[transition])
 

--- a/jiralib.py
+++ b/jiralib.py
@@ -15,7 +15,6 @@ OPEN_STATUS = "To Do"
 CLOSED_STATUS = "Done"
 
 # JIRA Webhook events
-DELETE_EVENT = 'jira:issue_deleted'
 UPDATE_EVENT = 'jira:issue_updated'
 
 DESC_TEMPLATE="""
@@ -66,7 +65,7 @@ class Jira:
 
     def create_hook(
         self, name, url, secret,
-        events=['jira:issue_updated', 'jira:issue_deleted'],
+        events=[UPDATE_EVENT],
         filters={'issue-related-events-section': ''},
         exclude_body=False
     ):

--- a/util.py
+++ b/util.py
@@ -154,4 +154,4 @@ class Sync:
             pairs[akey][1].append(i)
 
         for _, (alert, issues) in pairs.items():
-            self.sync(alert, issues, DIRECTION_G2J)    # TODO: We might want to make the direction configurable here
+            self.sync(alert, issues, DIRECTION_G2J)

--- a/util.py
+++ b/util.py
@@ -1,0 +1,6 @@
+import hashlib
+
+def make_key(s):
+    sha_1 = hashlib.sha1()
+    sha_1.update(s.encode('utf-8'))
+    return sha_1.hexdigest()

--- a/util.py
+++ b/util.py
@@ -1,6 +1,78 @@
 import hashlib
+from requests import HTTPError
+import logging
+
+REQUEST_TIMEOUT = 10
+
+logger = logging.getLogger(__name__)
+
 
 def make_key(s):
     sha_1 = hashlib.sha1()
     sha_1.update(s.encode('utf-8'))
     return sha_1.hexdigest()
+
+
+def json_accept_header():
+    return {'Accept': 'application/vnd.github.v3+json'}
+
+
+def sync_repo(ghrepository, jiraproject):
+    repo_id = ghrepository.repo_id
+
+    logger.info('Starting full sync for repository "{repo_id}"...'.format(repo_id=repo_id))
+
+    # fetch code scanning alerts from GitHub
+    cs_alerts = []
+    try:
+        cs_alerts = {make_key(repo_id + '/' + str(a['number'])): a for a in ghrepository.get_alerts()}
+    except HTTPError as httpe:
+        # if we receive a 404, the repository does not exist,
+        # so we will delete all related JIRA alert issues
+        if httpe.response.status_code != 404:
+            # propagate everything else
+            raise
+
+    # fetch issues from JIRA and delete duplicates and ones which can't be matched
+    jira_issues = {}
+    for i in jiraproject.fetch_issues(repo_id):
+        _, _, _, akey = i.get_alert_info()
+        if akey in jira_issues:
+            logger.warning(
+                'JIRA alert issues {ikey1} and {ikey2} have identical alert key {akey}!'.format(
+                    ikey1=i.key(),
+                    ikey2=jira_issues[akey].key(),
+                    akey=akey
+                )
+            )
+            i.delete()   # TODO - seems scary, are we sure....
+        elif akey not in cs_alerts:
+            logger.warning('JIRA alert issue {ikey} has no corresponding alert!'.format(ikey=i.key()))
+            i.delete()   # TODO - seems scary, are we sure....
+        else:
+            jira_issues[akey] = i
+
+    # create missing issues
+    for akey in cs_alerts:
+        if akey not in jira_issues:
+            alert = cs_alerts[akey]
+            rule = alert['rule']
+
+            jira_issues[akey] = jiraproject.create_issue(
+                repo_id,
+                rule['id'],
+                rule['description'],
+                alert['html_url'],
+                alert['number']
+            )
+
+    # adjust issue states
+    for akey in cs_alerts:
+        alert = cs_alerts[akey]
+        issue = jira_issues[akey]
+        astatus = alert['state']
+
+        if astatus == 'open':
+            issue.open()
+        else:
+            issue.close()


### PR DESCRIPTION
@johnlugton As mentioned, this splits up the GitHub and JIRA functions into their own modules. It also introduces a basic CLI tool. Here are a few examples:
* Synchronize a GitHub repo and a JIRA project:
```
./gh2jira sync  \
  --gh-url https://api.github.com \
  --gh-user zbazztian \
  --gh-token <ghtoken> \
  --gh-org ghas-performance-testing \
  --gh-repo newrepository \
  --jira-url https://jira.demo-stack.com  \
  --jira-user zbazztian \
  --jira-token <jira-password> \
  --jira-project JIR
```
* install the JIRA webhook:
```
./gh2jira hooks install \ 
  --hook-url https://something.com \ 
  --hook-secret <some-secret> \
  --jira-url https://jira.demo-stack.com \ 
  --jira-user zbazztian \
  --jira-token <jira-password>
```
* install the GitHub webhook for a repository (omit the --gh-repo param if webhook should be for entire organization)
```
./gh2jira hooks install \
  --gh-url https://api.github.com \
  --gh-user zbazztian \
  --gh-token <github-token> \
  --gh-org ghas-performance-testing \
  --gh-repo newrepository
```
* Lists existing webhooks:
```
./gh2jira hooks list  \
  --gh-url https://api.github.com \
  --gh-user zbazztian \
  --gh-token <github-token> \ 
  --gh-org ghas-performance-testing \
  --gh-repo newrepository \
  --jira-url https://jira.demo-stack.com \ 
  --jira-user zbazztian \
  --jira-token <jira-password>
```

It roughly works, but needs a lot more polishing. I will amend this PR tomorrow. Of course, if you are working on it today or are testing it, feel free to amend your improvements.