### PR TITLE
Update jiralib.py

### DIFF
--- a/jiralib.py
+++ b/jiralib.py
@@ -42,7 +42,7 @@ class Jira:
         self.url = url
         self.user = user
         self.token = token
-        self.j = JIRA(url, auth=(user, token))
+        self.j = JIRA(url, basic_auth=(user, token))
 
 
     def auth(self):


### PR DESCRIPTION
The  `/rest/auth/1/session` endpoint is deprecated for Jira Cloud, though this works for Server (at least the version we have 🤔).
https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-basic-auth-and-cookie-based-auth/

In addition, when using basic auth with this integration, we're going to have to use our email as the username and a Jira API token as the password.


@zbazztian 